### PR TITLE
実態に合わせるために記載情報の修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,47 +172,23 @@
                   <a href="works/01.html" style="background-image:url('./images/work/01/pict-work-firstview_pc.jpg');"></a>
                 </div>
                 <div class="works__item-text-block">
-                  <h3>ポートフォリオサイト</h3>
-                  <p>HTML/CSS/bootstrap4</p>
+                  <h3>FURIMA（フリマアプリ）</h3>
+                  <p>HTML/CSS/JavaScript/Ruby on Rails</p>
                 </div>
                 <div class="works__item-btn-block">
-                  <a href="__URL__" class="button">More</a>
+                  <a href="works/01.html" class="button">More</a>
                 </div>
               </li>
               <li class="works__item">
                 <div class="works__item-pict">
-                  <a href="works/01.html" style="background-image:url('./images/work/01/pict-work-firstview_pc.jpg');"></a>
+                  <a href="works/02.html" style="background-image:url('./images/work/01/pict-work-firstview_pc.jpg');"></a>
                 </div>
                 <div class="works__item-text-block">
-                  <h3>ポートフォリオサイト</h3>
-                  <p>HTML/CSS/bootstrap4</p>
+                  <h3>オリアプ（オリジナルアプリ）</h3>
+                  <p>HTML/CSS/JavaScript/Ruby on Rails</p>
                 </div>
                 <div class="works__item-btn-block">
-                  <a href="__URL__" class="button">More</a>
-                </div>
-              </li>
-              <li class="works__item">
-                <div class="works__item-pict">
-                  <a href="works/01.html" style="background-image:url('./images/work/01/pict-work-firstview_pc.jpg');"></a>
-                </div>
-                <div class="works__item-text-block">
-                  <h3>ポートフォリオサイト</h3>
-                  <p>HTML/CSS/bootstrap4</p>
-                </div>
-                <div class="works__item-btn-block">
-                  <a href="__URL__" class="button">More</a>
-                </div>
-              </li>
-              <li class="works__item">
-                <div class="works__item-pict">
-                  <a href="works/01.html" style="background-image:url('./images/work/01/pict-work-firstview_pc.jpg');"></a>
-                </div>
-                <div class="works__item-text-block">
-                  <h3>ポートフォリオサイト</h3>
-                  <p>HTML/CSS/bootstrap4</p>
-                </div>
-                <div class="works__item-btn-block">
-                  <a href="__URL__" class="button">More</a>
+                  <a href="works/02.html" class="button">More</a>
                 </div>
               </li>
             </ul>

--- a/works/02.html
+++ b/works/02.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>FURIMA（フリマアプリ）</title>
+    <title>オリアプ（オリジナルアプリ）</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="../css/style.css" />
   </head>
@@ -30,7 +30,7 @@
     <main>
       <section class="p-work-firstview">
         <div class="section-inner">
-          <h2>FURIMA（フリマアプリ）</h2>
+          <h2>オリアプ（オリジナルアプリ）</h2>
           <div class="p-work-firstview__pict obj-fit-img">
             <img src="../images/work/01/pict-work-firstview_pc.jpg" class="show-pc">
             <img src="../images/work/01/pict-work-firstview_sp.jpg" class="show-sp">
@@ -68,7 +68,7 @@
             </li>
             <li class="p-work-summary__item">
               <h3>動作テスト</h3>
-              <h4>購入テスト用アカウント</h4>
+              <h4>テスト用アカウント</h4>
               <table class="p-work-summary__item-table">
                 <tr>
                   <th>mail</th>
@@ -77,21 +77,6 @@
                 <tr>
                   <th>PASS</th>
                   <td>buyer_user</td>
-                </tr>
-              </table>
-              <h4>購入テスト用カード情報</h4>
-              <table class="p-work-summary__item-table">
-                <tr>
-                  <th>番号</th>
-                  <td>4242424242424242</td>
-                </tr>
-                <tr>
-                  <th>期限</th>
-                  <td>12/24</td>
-                </tr>
-                <tr>
-                  <th>CVC</th>
-                  <td>123</td>
                 </tr>
               </table>
             </li>
@@ -116,7 +101,20 @@
         <div class="section-inner">
           <ul class="p-work-about__list">
             <li class="p-work-about__item">
-              <h3>開発で苦労したこと</h3>
+              <h3>開発に至った経緯</h3>
+              <div class="p-work-about__item-block">
+                <p>
+                  がんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思った
+                  </br>
+                  がんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思った
+                </p>
+                <p>
+                    がんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思ったがんばろうと思った
+                </p>
+              </div>
+            </li>
+            <li class="p-work-about__item">
+              <h3>開発で工夫したこと</h3>
               <div class="p-work-about__item-block p-work-about__item-block-2column">
                 <div class="p-work-about__item-block-pict obj-fit-img">
                   <img src="../images/work/01/pict-work-about-dammy.jpg">


### PR DESCRIPTION
# Why
雛形として配布する際に、ある程度受講生が制作する内容に沿った状態である必要があるため。

# what
主に以下を変更

- 実際にFURIMAとオリアプの入力欄を作成した
- それに合わせて、各種要素の文言を変更した
- デフォルトで表示するworksを2に絞った（大体そのくらいなので）
- FURIMAとオリアプで記載する内容が若干ちがうので対応した